### PR TITLE
Remove dependabot.yml from starter pack

### DIFF
--- a/{{cookiecutter.name}}/.github/dependabot.yml
+++ b/{{cookiecutter.name}}/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-name: "github.com/conductorone/baton-sdk"


### PR DESCRIPTION
Why
New connector scaffolds should not include per-repo Dependabot config because dependency updates are handled through the central update path.

What this changes
Removes the Dependabot file from the generated connector template.